### PR TITLE
Fix axios vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "homepage": "https://github.com/JorgenVatle/discord-ts#readme",
   "devDependencies": {
-    "typescript": "^3.4.5"
+    "typescript": "^4.2"
   },
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.24.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export default class DiscordWebhook {
      */
     public constructor(webhookUrl: string) {
         this.client = Axios.create({
-            url: webhookUrl,
+          baseURL: webhookUrl,
         });
     }
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,7 +5,8 @@
         "strict": true,
         "esModuleInterop": true,
         "lib": [
-            "es6"
+            "es6",
+            "DOM"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Thanks for making the package man. It is still working great after making the following small changes:

- Updates axios to latest 24.x to fix critical vulns. 
- change `url` to `baseURL` in `DiscordWebhook` client constructor (axios v24 threw errors before making this change)

package updates:
- Updates to TSC 4.2.x
- Fixes ts spec to use DOM lib (for Axios changes)
